### PR TITLE
feat(modeling_internlm2.py): update model type to INTERNLM2_PUBLIC

### DIFF
--- a/configs/_base_/models/internlm2_20B.py
+++ b/configs/_base_/models/internlm2_20B.py
@@ -1,6 +1,6 @@
 # Copyright (c) InternLM. All rights reserved.
 
-model_type = "INTERNLM2"
+model_type = "INTERNLM2_PUBLIC"
 
 VOCAB_SIZE = 92544
 HIDDEN_SIZE = 6144

--- a/configs/_base_/models/internlm2_7B.py
+++ b/configs/_base_/models/internlm2_7B.py
@@ -1,6 +1,6 @@
 # Copyright (c) InternLM. All rights reserved.
 
-model_type = "INTERNLM2"
+model_type = "INTERNLM2_PUBLIC"
 
 VOCAB_SIZE = 92544
 HIDDEN_SIZE = 4096

--- a/internlm/model/modeling_internlm2.py
+++ b/internlm/model/modeling_internlm2.py
@@ -49,7 +49,7 @@ from internlm.utils.common import filter_kwargs
 from internlm.utils.logger import get_logger
 from internlm.utils.registry import MODEL_INITIALIZER
 
-MODEL_TYPE = "INTERNLM2"
+MODEL_TYPE = "INTERNLM2_PUBLIC"
 
 logger = get_logger(__file__)
 RMSNorm = try_import_RMSNorm()

--- a/internlm/model/modeling_internlm2.py
+++ b/internlm/model/modeling_internlm2.py
@@ -928,7 +928,7 @@ class PackedFlashLlama1D(nn.Module):
                     "Parameter ``norm_head`` should only be True when head_cls is "
                     f"``InternLM2ScaleColumnParallelLinear``, instead of {head_cls}."
                 )
-            self.output = head_cls(
+            self.output = head_cls(  # pylint: disable=E1123
                 in_features=hidden_size,
                 out_features=gpc.get_world_size(ParallelMode.TENSOR) if is_reward else vocab_size,
                 process_group=gpc.get_group(ParallelMode.TENSOR),


### PR DESCRIPTION
## Motivation

Change the `MODEL_TYPE` of InternLM2 in the public repository to `INTERNLM2_PUBLIC` to avoid duplication with the private repository, preventing potential errors.

