### PR TITLE
fix(communication/isp.py): fix redundant callback and remove head embed hook

### DIFF
--- a/internlm/core/communication/utils.py
+++ b/internlm/core/communication/utils.py
@@ -221,8 +221,8 @@ class ParamAsyncBcastHandler:
                 block, (Embedding1D, ParallelGPT2Embeddings, BaseScaleColumnParallelLinear)
             ):
                 block.register_forward_pre_hook(_pre_forward_hook)
-            else:
-                isp_communicator.register_prerequisite_for_forward_prefetch_hooks(_pre_forward_hook)
+        if isp_communicator:
+            isp_communicator.register_prerequisite_for_forward_prefetch_hooks(_pre_forward_hook)
 
     def get_rank_by_param(self, param) -> int:
         return self._param_to_rank[param]

--- a/internlm/utils/model_checkpoint.py
+++ b/internlm/utils/model_checkpoint.py
@@ -538,9 +538,13 @@ def load_model_checkpoint(folder, model):
     - folder
         - model_tp{tp_rank}_pp{pp_rank}.pt
 
+    If tensor parallel mode is isp, the saved weight is named:
+    - folder
+        - model_tp{tp_rank}_wp{wp_rank}_pp{pp_rank}.pt
+
     If fsdp is activated, the saved weight is named:
     - folder
-        - model_tp{tp_rank}_pp{pp_rank}_zo{zo_rank}
+        - model_tp{tp_rank}_pp{pp_rank}_zo{zo_rank}.pt
 
     If the tp is inconsistent with the saved one in the future use, the weight needs to be converted before loading.
     """
@@ -549,6 +553,7 @@ def load_model_checkpoint(folder, model):
     wp_size = gpc.get_world_size(ParallelMode.WEIGHT)
     pp_size = gpc.get_world_size(ParallelMode.PIPELINE)
     dp_size = gpc.get_world_size(ParallelMode.DATA)
+
     tp_rank = gpc.get_local_rank(ParallelMode.TENSOR)
     wp_rank = gpc.get_local_rank(ParallelMode.WEIGHT)
     pp_rank = gpc.get_local_rank(ParallelMode.PIPELINE)


### PR DESCRIPTION
## Motivation

Optimize isp communicator.

## Modification

1. Remove redundant registration of callback functions for `ParamAsyncBcastHandler`.
2. Fix the issue where the broadcast handle is not waited for due to the first block not invoking the `_all_gather_block_weight` prefetch weight interface during the intermediate stage when pp is enabled.
3. In the forward phase, eliminate the weight prefetch for the first block by the `Embedding` layer, and instead uniformly register a prefetch hook for the first block.
4. In the backward phase, eliminate the weight prefetch for the last block by the `head` layer, and instead uniformly register a prefetch hook for the last module.