### PR TITLE
Fix(TrainState): fix trainstate batch sampler

### DIFF
--- a/internlm/train/pipeline.py
+++ b/internlm/train/pipeline.py
@@ -381,6 +381,8 @@ def load_new_batch(train_dl: DataLoader, train_iter: Iterable, train_state: Trai
         batch = next(train_iter)
         train_state.num_consumed_samples_in_epoch = 0
         if hasattr(train_state, "batch_sampler"):
+            train_state.batch_sampler.batch_count = 0
+            train_state.batch_sampler.num_consumed_samples_in_epoch = 0
             train_state.batch_sampler_iter = iter(train_state.batch_sampler)
             next(train_state.batch_sampler_iter)
     timer("batch-gen").stop()


### PR DESCRIPTION
## Motivation

Bug fix when the number of dataset samples is not enough to run through total steps.
https://github.com/InternLM/InternEvo/issues/77

## Modification

We reset the `train_state.batch_sampler.batch_count` and `train_state.batch_sampler.num_consumed_samples_in_epoch` before re-creating `train_state.batch_sampler_iter` generator in the StopIteration exception handling.

## BC-breaking (Optional)

None
## Use cases (Optional)

None

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
