### PR TITLE
fix(gpc): remove unused num_processes_on_current_node

### DIFF
--- a/internlm/core/context/parallel_context.py
+++ b/internlm/core/context/parallel_context.py
@@ -4,11 +4,9 @@
 # adopted from https://github.com/hpcaitech/ColossalAI/blob/main/colossalai/context
 
 import inspect
-import os
 import random
 import socket
 import sys
-from collections import Counter
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
 from typing import Union
@@ -17,7 +15,7 @@ import numpy as np
 import torch
 import torch.distributed as dist
 
-from internlm.accelerator import AcceleratorType, get_accelerator
+from internlm.accelerator import get_accelerator
 from internlm.utils.common import SingletonMeta
 from internlm.utils.logger import get_logger
 from internlm.utils.timeout import LLM_NCCL_TIMEOUT
@@ -198,23 +196,6 @@ class ParallelContext(metaclass=SingletonMeta):
             self._config = Config(config)
         else:
             raise TypeError("Invalid type for config, only dictionary or string is supported")
-
-    def detect_num_processes_on_current_node(self):
-        hostname = socket.gethostname()
-        hostname_list = [None for _ in range(self.get_world_size(ParallelMode.GLOBAL))]
-
-        if internlm_accelerator.get_accelerator_backend() == AcceleratorType.NPU:
-            if "A_K" in os.environ:
-                self.num_processes_on_current_node = 8
-            elif "A_X" in os.environ:
-                self.num_processes_on_current_node = 16
-            else:
-                self.num_processes_on_current_node = 8
-            logger.warning(f"'try set 'num_processes_on_current_node' as {self.num_processes_on_current_node}")
-        else:
-            dist.all_gather_object(hostname_list, hostname, group=self.get_group(ParallelMode.GLOBAL))
-            counter = Counter(hostname_list)
-            self.num_processes_on_current_node = counter[hostname]
 
     @staticmethod
     def _check_parallel_mode(parallel_mode: ParallelMode):

--- a/internlm/initialize/launch.py
+++ b/internlm/initialize/launch.py
@@ -499,10 +499,6 @@ def launch(
         # if local rank is not given, calculate automatically
         gpc.set_device(local_rank)
 
-    # set the number of processes running on the same node
-    gpc.detect_num_processes_on_current_node()
-
-    get_accelerator().synchronize()
     gpc.set_seed(seed)
 
     warmup_process_group()


### PR DESCRIPTION
## Motivation && Modification

Remove the unused `num_processes_on_current_node` from gpc to prevent `all_gather_object `from reporting an error on the npu device.

## BC-breaking (Optional)


## Use cases (Optional)


## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
