### PR TITLE
feat(internlm): remove use_cuda_flash_attn

### DIFF
--- a/internlm/checkpoint/utils.py
+++ b/internlm/checkpoint/utils.py
@@ -58,15 +58,12 @@ def get_model_topology(model):
         where name is the name of the module, and all parameters under this module are
         concatenated along the dimension 'dim'.
     """
-
-    from flash_attn.modules.embedding import VocabParallelEmbedding
-
     topos = {}
-    for name, module in model.named_modules():
-        # If it does not meet these conditions, it is shared between various tp/dp, and it is necessary to assert
+    for name, module in model.named_modules():  # pylint: disable=W0612
+        # TODO: If it does not meet these conditions, it is shared between various tp/dp, and it is necessary to assert
         # that they are consistent.
-        if isinstance(module, VocabParallelEmbedding):
-            topos[name] = {"dim": 0}
+        # In order to be compatible with CI, this function will not be deleted for now.
+        pass
     return topos
 
 

--- a/internlm/initialize/launch.py
+++ b/internlm/initialize/launch.py
@@ -321,15 +321,9 @@ def args_sanity_check():
     if "use_flash_attn" not in gpc.config.model:
         gpc.config.model._add_item("use_flash_attn", True)
 
-    gpc.config["use_cuda_flash_attn"] = False
-    if gpc.config.model.use_flash_attn and (
-        internlm_accelerator.get_accelerator_backend() in [AcceleratorType.GPU, AcceleratorType.DIPU]
-    ):
-        gpc.config["use_cuda_flash_attn"] = True
-
     old_parallel_output = gpc.config.model.get("parallel_output", None)
     # Try to change user setting
-    if not gpc.config.use_cuda_flash_attn:
+    if internlm_accelerator.get_accelerator_backend() is not AcceleratorType.GPU:
         gpc.config.model.update({"parallel_output": False})
         if old_parallel_output is True and gpc.is_rank_for_log():
             logger.warning(

--- a/internlm/model/modeling_internlm.py
+++ b/internlm/model/modeling_internlm.py
@@ -14,11 +14,11 @@ from internlm.initialize.initialize_tensor import normal_, scaled_init_method_no
 from internlm.model.modules.embedding import Embedding1D
 from internlm.model.modules.mlp import get_mlp_cls
 from internlm.model.modules.multi_head_attention import MHA
+from internlm.model.ops.fusion_ops_import_helper import try_import_RMSNorm
 from internlm.model.ops.linear import RewardModelLinear, ScaleColumnParallelLinear
 from internlm.model.utils import (
     gather_forward_split_backward,
     split_forward_gather_backward,
-    try_import_RMSNorm,
 )
 from internlm.solver.activation_checkpoint import activation_checkpoint
 from internlm.solver.pipeline_utils import partition_uniform
@@ -130,24 +130,6 @@ class PackedFlashBaseLayer1D(nn.Module):
                 mlp_layer_fusion=mlp_layer_fusion,
                 sequence_parallel=gpc.config.parallel.sequence_parallel,
                 multiple_of=multiple_of,
-            )
-        else:
-            assert gpc.config.use_cuda_flash_attn is True
-            from flash_attn.modules.mlp import ParallelFusedMLP
-
-            self.mlp = ParallelFusedMLP(
-                hidden_size,
-                int(hidden_size * mlp_ratio),
-                out_features=hidden_size,
-                activation="gelu_approx",
-                process_group=gpc.get_group(parallel_mode),
-                bias1=False,
-                bias2=False,
-                sequence_parallel=gpc.config.parallel.sequence_parallel,
-                checkpoint_lvl=0,
-                heuristic="auto",
-                device=device,
-                dtype=dtype,
             )
 
         self.dropout2 = nn.Dropout(drop_rate)
@@ -318,21 +300,9 @@ class PackedFlashInternLm1D(nn.Module):
         else:
             head_cls = ScaleColumnParallelLinear
         if first:
-            if embed_split_hidden or not gpc.config.use_cuda_flash_attn:
-                self.embedding = Embedding1D(num_embeddings=vocab_size, embedding_dim=hidden_size)
-            else:
-                from flash_attn.modules.embedding import ParallelGPT2Embeddings
-
-                self.embedding = ParallelGPT2Embeddings(
-                    embed_dim=hidden_size,
-                    vocab_size=vocab_size,
-                    max_position_embeddings=-1,
-                    process_group=gpc.get_group(ParallelMode.TENSOR),
-                    padding_idx=None,
-                    sequence_parallel=gpc.config.parallel.sequence_parallel,
-                    device=device,
-                    dtype=dtype,
-                )
+            self.embedding = Embedding1D(
+                num_embeddings=vocab_size, embedding_dim=hidden_size, embed_split_hidden=embed_split_hidden
+            )
             for _, param in self.embedding.named_parameters():
                 normal_(std=0.0052)(param)
         self.embed_grad_scale = embed_grad_scale

--- a/internlm/model/modeling_llama.py
+++ b/internlm/model/modeling_llama.py
@@ -22,6 +22,7 @@ from internlm.model.modules.multi_head_attention import (
     _update_kv_cache,
     get_gqa_attn_cls,
 )
+from internlm.model.ops.fusion_ops_import_helper import try_import_RMSNorm
 from internlm.model.ops.linear import (
     RewardModelLinear,
     ScaleColumnParallelLinear,
@@ -31,7 +32,6 @@ from internlm.model.utils import (
     gather_forward_split_backward,
     pack_output_after_attn,
     split_forward_gather_backward,
-    try_import_RMSNorm,
     unpack_qkv_before_attn,
 )
 from internlm.solver.activation_checkpoint import activation_checkpoint
@@ -281,7 +281,6 @@ class MHA(nn.Module):
             kv = torch.where(torch.isnan(kv), 0, kv)
 
             if hasattr(inference_params, "attention_mask") and inference_params.attention_mask is not None:
-                assert gpc.config.use_cuda_flash_attn is True
                 from flash_attn.flash_attn_interface import FlashAttnVarlenKVPackedFunc
 
                 if inference_params.sequence_len_offset == 0:  # First entrance, attnmask (bs*seqlen*seqlen)
@@ -576,44 +575,19 @@ class PackedFlashLlamaLayer1D(nn.Module):
         else:
             self.attention_norm = nn.LayerNorm(hidden_size, eps=layer_norm_epsilon)
             self.ffn_norm = nn.LayerNorm(hidden_size, eps=layer_norm_epsilon)
-        if self.fused_dropout_add_ln and gpc.config.use_cuda_flash_attn:
-            from flash_attn.ops.layer_norm import dropout_add_layer_norm
 
-            assert dropout_add_layer_norm is not None, "dropout_add_ln is not installed"
-            assert isinstance(self.attention_norm, nn.LayerNorm) and isinstance(self.dropout1, nn.Dropout)
-
-        sequence_parallel = gpc.config.parallel.get("sequence_parallel", False)
-        if use_swiglu or not gpc.config.use_cuda_flash_attn:
-            mlp_cls = get_mlp_cls(self.tp_mode)
-            self.feed_forward = mlp_cls(
-                hidden_size,
-                int(hidden_size * mlp_ratio),
-                out_features=hidden_size,
-                process_group=gpc.get_group(parallel_mode),
-                bias=False,
-                device=device,
-                dtype=dtype,
-                mlp_layer_fusion=mlp_layer_fusion,
-                sequence_parallel=gpc.config.parallel.sequence_parallel,
-                multiple_of=multiple_of,
-            )
-        else:
-            from flash_attn.modules.mlp import ParallelFusedMLP
-
-            self.feed_forward = ParallelFusedMLP(
-                hidden_size,
-                int(hidden_size * mlp_ratio),
-                out_features=hidden_size,
-                activation="gelu_approx",
-                process_group=gpc.get_group(parallel_mode),
-                bias1=False,
-                bias2=False,
-                sequence_parallel=sequence_parallel,
-                checkpoint_lvl=0,
-                heuristic="auto",
-                device=device,
-                dtype=dtype,
-            )
+        self.feed_forward = get_mlp_cls(self.tp_mode)(
+            hidden_size,
+            int(hidden_size * mlp_ratio),
+            out_features=hidden_size,
+            process_group=gpc.get_group(parallel_mode),
+            bias=False,
+            device=device,
+            dtype=dtype,
+            mlp_layer_fusion=mlp_layer_fusion,
+            sequence_parallel=gpc.config.parallel.get("sequence_parallel", False),
+            multiple_of=multiple_of,
+        )
 
         self.dropout2 = nn.Dropout(drop_rate)
         self.use_swiglu = use_swiglu
@@ -839,7 +813,6 @@ class PackedFlashLlama1D(nn.Module):
         if not checkpoint:
             checkpoint_fraction = 0
         checkpoint_layer_num = num_layers * checkpoint_fraction
-        sequence_parallel = gpc.config.parallel.get("sequence_parallel", False)
         self.tp_mode = "mtp"
         if isinstance(gpc.config.parallel["tensor"], dict):
             self.tp_mode = gpc.config.parallel["tensor"].get("mode", "mtp")
@@ -850,21 +823,9 @@ class PackedFlashLlama1D(nn.Module):
             head_cls = ScaleColumnParallelLinear
 
         if first:
-            if embed_split_hidden or not gpc.config.use_cuda_flash_attn:
-                self.tok_embeddings = Embedding1D(num_embeddings=vocab_size, embedding_dim=hidden_size)
-            else:
-                from flash_attn.modules.embedding import ParallelGPT2Embeddings
-
-                self.tok_embeddings = ParallelGPT2Embeddings(
-                    embed_dim=hidden_size,
-                    vocab_size=vocab_size,
-                    max_position_embeddings=-1,
-                    process_group=gpc.get_group(ParallelMode.TENSOR),
-                    padding_idx=None,
-                    sequence_parallel=sequence_parallel,
-                    device=device,
-                    dtype=dtype,
-                )
+            self.tok_embeddings = Embedding1D(
+                num_embeddings=vocab_size, embedding_dim=hidden_size, embed_split_hidden=embed_split_hidden
+            )
             for _, param in self.tok_embeddings.named_parameters():
                 if init_type == "normal":
                     normal_(std=embedding_init_std)(param)

--- a/internlm/model/modules/multi_head_attention.py
+++ b/internlm/model/modules/multi_head_attention.py
@@ -755,23 +755,22 @@ class MHA(nn.Module):
                             if total_kv.dtype not in [torch.float16, torch.bfloat16]:
                                 total_kv = total_kv.to(torch.bfloat16)
 
-                    if gpc.config.use_cuda_flash_attn:
+                    try:
+                        from flash_attn.flash_attn_interface import (
+                            flash_attn_unpadded_func,
+                        )
+                    except ImportError:
                         try:
                             from flash_attn.flash_attn_interface import (
-                                flash_attn_unpadded_func,
+                                flash_attn_unpadded_kvpacked_func as flash_attn_unpadded_func,
                             )
                         except ImportError:
                             try:
                                 from flash_attn.flash_attn_interface import (
-                                    flash_attn_unpadded_kvpacked_func as flash_attn_unpadded_func,
+                                    flash_attn_varlen_kvpacked_func as flash_attn_unpadded_func,
                                 )
                             except ImportError:
-                                try:
-                                    from flash_attn.flash_attn_interface import (
-                                        flash_attn_varlen_kvpacked_func as flash_attn_unpadded_func,
-                                    )
-                                except ImportError:
-                                    raise ImportError("Please check your flash_attn version >= 1.0.5.")
+                                raise ImportError("Please check your flash_attn version >= 1.0.5.")
 
                         output = flash_attn_unpadded_func(
                             total_q,

--- a/internlm/model/ops/fusion_ops_import_helper.py
+++ b/internlm/model/ops/fusion_ops_import_helper.py
@@ -1,0 +1,225 @@
+from typing import Callable, Tuple, Union
+
+import torch
+from torch import nn
+
+from internlm.accelerator import AcceleratorType, get_accelerator
+from internlm.core.context import ParallelMode
+from internlm.core.context import global_context as gpc
+from internlm.utils.logger import get_logger
+
+logger = get_logger(__file__)
+
+internlm_accelerator = get_accelerator()
+
+
+# RMSNorm
+def try_import_RMSNorm():
+    """
+    Try import MixFusedRMSNorm from apex, if failed, return our RMSNorm
+
+    """
+    try:
+        device_backend = internlm_accelerator.get_accelerator_backend()
+        if device_backend == AcceleratorType.DIPU:
+            from deeplink_ext.internlm_ops.rms_norm import (
+                DeepLinkRMSNormWithNormalizedShape as RMSNorm,
+            )
+
+            if gpc.is_rank_for_log():
+                logger.warning("Use DeepLinkRMSNormWithNormalizedShape, Please note this!")
+
+            return RMSNorm
+        else:
+            from apex.normalization.fused_layer_norm import MixedFusedRMSNorm as RMSNorm
+
+            if gpc.is_rank_for_log():
+                logger.warning("Use apex MixedFusedRMSNorm, Please note this!")
+
+            return RMSNorm
+    except (ModuleNotFoundError, ImportError):
+        if gpc.is_rank_for_log():
+            logger.warning("The torch implementation for MixFusedRMSNorm is slower than apex. Please note this!")
+        from internlm.model.ops.norm import RMSNormTorch as RMSNorm
+
+        return RMSNorm
+
+
+# RotaryEmb
+def try_import_fused_rotary() -> Tuple[Union[None, Callable], Union[None, Callable], Union[None, Callable]]:
+    """try_import_fused_rotary
+
+    Returns:
+        Tuple[Union[None, Callable], Union[None, Callable], Union[None, Callable]]:
+            Returns if there is a mixing operator available, otherwise returns None.
+    """
+    try:
+        device_backend = internlm_accelerator.get_accelerator_backend()
+        if device_backend is AcceleratorType.GPU:
+            import rotary_emb
+
+            if gpc.is_rank_for_log():
+                logger.warning("Use flash_attn rotary_emb, Please note this!")
+
+            return None, None, rotary_emb.apply_rotary
+        elif device_backend is AcceleratorType.DIPU:
+            from deeplink_ext.internlm_ops.rotary.deeplink import (
+                DeeplinkApplyRotaryEmb,
+                DeeplinkApplyRotaryEmbQKV_,
+            )
+
+            if gpc.is_rank_for_log():
+                logger.warning("Use DeeplinkApplyRotaryEmb, Please note this!")
+
+            return DeeplinkApplyRotaryEmb, DeeplinkApplyRotaryEmbQKV_, None
+
+    except (ModuleNotFoundError, ImportError):
+        pass
+
+    if gpc.is_rank_for_log():
+        logger.warning(
+            "The torch implementation for apply_rotary is slower" "than flash atten rotary_emb. Please note this!"
+        )
+    return None, None, None
+
+
+# ParallelGPT2Embeddings
+def try_import_ParallelGPT2Embeddings(embed_split_hidden):
+    try:
+        device_backend = internlm_accelerator.get_accelerator_backend()
+
+        if not embed_split_hidden:
+            if device_backend is AcceleratorType.GPU:
+                from flash_attn.modules.embedding import ParallelGPT2Embeddings
+
+                return ParallelGPT2Embeddings
+
+    except (ModuleNotFoundError, ImportError):
+        pass
+
+    return None
+
+
+# CrossEntropyLoss
+def internlm_init_CrossEntropyLoss(
+    parallel_output: bool, reduction="none", label_smoothing=0, inplace_backward=True, process_group=None, **kwargs
+):
+    """
+    Try import FlashCrossEntropyLoss from flash_attn, if failed, return our CrossEntropyLoss
+
+    """
+    if parallel_output:
+        try:
+            if internlm_accelerator.get_accelerator_backend() is AcceleratorType.GPU:
+                from flash_attn.losses.cross_entropy import (
+                    CrossEntropyLoss as FlashCrossEntropyLoss,
+                )
+
+                if process_group is None:
+                    gpc.get_group(ParallelMode.TENSOR)
+
+                if gpc.is_rank_for_log():
+                    logger.warning("Use flash_attn FlashCrossEntropyLoss, Please note this!")
+
+                return FlashCrossEntropyLoss(
+                    reduction=reduction,
+                    inplace_backward=inplace_backward,
+                    process_group=process_group,
+                    label_smoothing=label_smoothing,
+                    **kwargs,
+                )
+        except (ModuleNotFoundError, ImportError):
+            pass
+
+    if gpc.is_rank_for_log():
+        logger.warning(
+            "Use nn.CrossEntropyLoss rather than CrossEntropyLoss."
+            "parallel_output must be set false. Please note this!"
+        )
+
+    kwargs.pop("process_group")
+    kwargs.pop("inplace_backward")
+
+    return nn.CrossEntropyLoss(reduction=reduction, label_smoothing=label_smoothing, **kwargs)
+
+
+# Adamw
+def try_import_FusedAdamW():
+    """
+    Try import FusedAdamW from torch_npu/torch
+
+    """
+    adam_extra_kwargs = {}
+    backend = internlm_accelerator.get_accelerator_backend()
+    try:
+        if backend is AcceleratorType.GPU:
+            adam_extra_kwargs["fused"] = True
+
+            if gpc.is_rank_for_log():
+                logger.warning(
+                    "Use fused AdamaW to avoid nan grad norm when "
+                    "model size is larger and use_fp32_norm=True, Please note this!"
+                )
+            return adam_extra_kwargs, torch.optim.AdamW
+        elif backend is AcceleratorType.NPU:
+
+            if gpc.is_rank_for_log():
+                logger.warning(
+                    "Use normal AdamaW, NPU fused_adamw currently has"
+                    "accuracy issues and is not supported yet. Please note this!"
+                )
+            # return adam_extra_kwargs, torch_npu.optim.NpuFusedAdamW
+    except (ModuleNotFoundError, ImportError):
+        pass
+
+    if gpc.is_rank_for_log():
+        logger.warning("Use torch.optim.AdamW rather than FusedAdamW. Please note this!")
+    return adam_extra_kwargs, torch.optim.AdamW
+
+
+# scatter_sum
+def try_import_scatter_sum():
+    """
+    Try import scatter_sum from cuda, if failed, return None
+
+    """
+    try:
+        if internlm_accelerator.get_accelerator_backend() in [AcceleratorType.GPU, AcceleratorType.DIPU]:
+            from torch_scatter import scatter as cuda_scatter
+
+            if gpc.is_rank_for_log():
+                logger.warning("Use cuda_scatter. Please note this!")
+
+            return cuda_scatter
+
+    except (ModuleNotFoundError, ImportError):
+        pass
+
+    if gpc.is_rank_for_log():
+        logger.warning("Use vanilla_scatter rather than cuda_scatter. Please note this!")
+
+    return None
+
+
+# FlashAttn
+def try_import_linear_bias_wgrad():
+    """
+    Try import linear_bias_wgrad from flash_attn, if failed, return None
+
+    """
+    try:
+        if internlm_accelerator.get_accelerator_backend() is AcceleratorType.GPU:
+            import fused_dense_lib as fused_dense_cuda
+
+            if gpc.is_rank_for_log():
+                logger.warning("Use flash_attn linear_bias_wgrad. Please note this!")
+
+            return fused_dense_cuda.linear_bias_wgrad
+
+    except (ModuleNotFoundError, ImportError):
+        pass
+
+    if gpc.is_rank_for_log():
+        logger.warning("Use linear_bias_wgrad_torch. Please note this!")
+
+    return None

--- a/internlm/model/ops/fusion_ops_import_helper.py
+++ b/internlm/model/ops/fusion_ops_import_helper.py
@@ -137,8 +137,10 @@ def internlm_init_CrossEntropyLoss(
             "parallel_output must be set false. Please note this!"
         )
 
-    kwargs.pop("process_group")
-    kwargs.pop("inplace_backward")
+    if "process_group" in kwargs:
+        kwargs.pop("process_group")
+    if "inplace_backward" in kwargs:
+        kwargs.pop("inplace_backward")
 
     return nn.CrossEntropyLoss(reduction=reduction, label_smoothing=label_smoothing, **kwargs)
 

--- a/internlm/utils/parallel.py
+++ b/internlm/utils/parallel.py
@@ -12,7 +12,7 @@ from internlm.core.context import (
     ParallelMode,
 )
 from internlm.core.context import global_context as gpc
-from internlm.model.utils import try_import_RMSNorm
+from internlm.model.ops.fusion_ops_import_helper import try_import_RMSNorm
 
 RMSNorm = try_import_RMSNorm()
 

--- a/tests/test_core/test_pipeline.py
+++ b/tests/test_core/test_pipeline.py
@@ -82,7 +82,6 @@ config = Config(
             eta_min=1e-5,
             last_epoch=-1,
         ),
-        use_cuda_flash_attn=True,
     )
 )
 

--- a/tests/test_data/test_batch_sampler.py
+++ b/tests/test_data/test_batch_sampler.py
@@ -175,7 +175,6 @@ def test_warmup(use_flash_atten_case, group_case, micro_bsz_case):
             adam=dict(lr=1e-4),
             resume_tb_folder=None,
             tensorboard_folder=None,
-            use_cuda_flash_attn=True,
         )
     )
 

--- a/tests/test_model/test_model_internlm.py
+++ b/tests/test_model/test_model_internlm.py
@@ -57,7 +57,6 @@ config = Config(
         resume_tb_folder="",
         tensorboard_folder="",
         alert_address=None,
-        use_cuda_flash_attn=True,
         monitor=dict(alert=dict(enable_feishu_alert=False, feishu_alert_address=None, light_monitor_address=None)),
     )
 )

--- a/tests/test_model/test_norm.py
+++ b/tests/test_model/test_norm.py
@@ -3,7 +3,7 @@ import multiprocessing as mp
 import pytest
 import torch
 
-from internlm.model.utils import try_import_RMSNorm
+from internlm.model.ops.fusion_ops_import_helper import try_import_RMSNorm
 from internlm.utils.common import get_current_device
 from tests.test_model.test_model_internlm import build_environment, seed_all
 

--- a/tests/test_model/test_npu_ops.py
+++ b/tests/test_model/test_npu_ops.py
@@ -16,7 +16,7 @@ from internlm.model.modules.multi_head_attention import (
     CrossAttention,
     SelfAttention,
 )
-from internlm.model.utils import try_import_RMSNorm
+from internlm.model.ops.fusion_ops_import_helper import try_import_RMSNorm
 
 RMSNorm = try_import_RMSNorm()
 

--- a/tests/test_solver/test_optimizer.py
+++ b/tests/test_solver/test_optimizer.py
@@ -82,7 +82,6 @@ config = Config(
             reduce_bucket_size=512 * 1024 * 1024,
             clip_grad_norm=1.0,
         ),
-        use_cuda_flash_attn=True,
     )
 )
 

--- a/tests/test_training/test_forward_output_no_fa.py
+++ b/tests/test_training/test_forward_output_no_fa.py
@@ -110,7 +110,6 @@ config = Config(
         loss=dict(
             label_smoothing=0,
         ),
-        use_cuda_flash_attn=True,
     )
 )
 
@@ -129,7 +128,7 @@ def build_environment(rank, world_size, free_port, config):
     os.environ["MASTER_PORT"] = str(free_port)
     internlm_accelerator.empty_cache()
     # launcher="torch"
-    internlm.launch_from_torch(config=config, seed=1024)
+    internlm.launch_from_torch(config=config, seed=1024, backend="hccl")
     args_sanity_check()
 
 

--- a/tests/test_training/test_forward_output_no_fa.py
+++ b/tests/test_training/test_forward_output_no_fa.py
@@ -127,8 +127,7 @@ def build_environment(rank, world_size, free_port, config):
     os.environ["MASTER_ADDR"] = "localhost"
     os.environ["MASTER_PORT"] = str(free_port)
     internlm_accelerator.empty_cache()
-    # launcher="torch"
-    internlm.launch_from_torch(config=config, seed=1024, backend="hccl")
+    internlm.launch_from_torch(config=config, seed=1024)
     args_sanity_check()
 
 

--- a/tests/test_training/test_load_ckpt_loss.py
+++ b/tests/test_training/test_load_ckpt_loss.py
@@ -154,7 +154,6 @@ config = Config(
         loss=dict(
             label_smoothing=0,
         ),
-        use_cuda_flash_attn=True,
     )
 )
 

--- a/tests/test_training/test_swap_nb_loss_and_gradnorm.py
+++ b/tests/test_training/test_swap_nb_loss_and_gradnorm.py
@@ -120,7 +120,6 @@ config = Config(
             label_smoothing=0,
         ),
         cudnn_deterministic=True,
-        use_cuda_flash_attn=True,
     )
 )
 


### PR DESCRIPTION
## Motivation
Remove use_cuda_flash_attn from InternEvo.

Try to hide the differences between different hardware (e.g. GPU, NPU) and packages (e.g. torch_npu, dipu) in the underlying modules to simplify the implementation of modeling.

## Modification

1. remove `use_cuda_flash_attn`.
2. remove '`ParallelFusedMLP`'.
3. remove '`ParallelGPT2Embeddings`'.
4. add `internlm/model/ops/fusion_ops_import_helper.py` to handle the import of different fusion ops.
5. set fused_adamw as False if backend is NPU.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
