### PR TITLE
fix(train/utils.py): fix moe and fp32 param group split when model dtype is fp32

### DIFF
--- a/internlm/train/utils.py
+++ b/internlm/train/utils.py
@@ -61,11 +61,11 @@ def split_params_into_different_groups_for_optimizer(
             if is_tensor_data_parallel_parameter(param):
                 # should not be here if not isp mode
                 new_groups["embed_head"]["params"].append(param)
-            elif param.dtype == torch.float32:
-                new_groups["fp32"]["params"].append(param)
             # moe param means MoE is enabled
             elif is_moe_param(param):
                 new_groups[param.group_name]["params"].append(param)
+            elif param.dtype == torch.float32 and gpc.config.model.dtype != torch.float32:
+                new_groups["fp32"]["params"].append(param)
             else:
                 origin_params.append(param)
 


### PR DESCRIPTION
## Motivation

Fix moe and fp32 param group split when model dtype is fp32.
