### PR TITLE
feat(GQA): support the sequence parallel when sp size > kv head

### DIFF
--- a/internlm/core/parallel/comm/isp.py
+++ b/internlm/core/parallel/comm/isp.py
@@ -19,8 +19,8 @@ from internlm.core.parallel.comm.utils import (
     DUMMY_HANDLE_CONST,
     AsyncCommHandle,
     all_gather_raw,
-    reduce_scatter_raw,
     expandKVPacked,
+    reduce_scatter_raw,
 )
 from internlm.model.modules.linear import ParallelLinearWithCommExt
 from internlm.utils.common import SchedulerHook, get_current_device

--- a/internlm/core/parallel/comm/isp.py
+++ b/internlm/core/parallel/comm/isp.py
@@ -20,6 +20,7 @@ from internlm.core.parallel.comm.utils import (
     AsyncCommHandle,
     all_gather_raw,
     reduce_scatter_raw,
+    expandKVPacked,
 )
 from internlm.model.modules.linear import ParallelLinearWithCommExt
 from internlm.utils.common import SchedulerHook, get_current_device
@@ -670,6 +671,7 @@ class DistributedAttention(nn.Module):
         super().__init__()
         self.local_attn = local_attention
         self.spg = sequence_process_group
+        self.sp_size = gpc.config.parallel["tensor"].get("size")
 
     @params_dispatch_with_condition(condition=check_attention_argument)
     def forward(self) -> torch.Tensor:
@@ -717,6 +719,11 @@ class DistributedAttention(nn.Module):
         q = _SeqAllToAll.apply(self.spg, q, 2, 1)
         # kv shape: [1, packlen, 2, n_head, head_dim] or [batch, seqlen, 2, n_head, head_dim]
         # scatter in n_head and gather in seqlen(packlen)
+        num_head_kv = kv.shape[3]
+        # if the num head of kv is not enough to be splitted by sp
+        # then we could copy the kv head
+        if self.sp_size > num_head_kv:
+            kv = expandKVPacked(kv, self.sp_size, 3)
         kv = _SeqAllToAll.apply(self.spg, kv, 3, 1)
 
         context = self.local_attn(q, kv, **kwargs)

--- a/internlm/core/parallel/comm/isp.py
+++ b/internlm/core/parallel/comm/isp.py
@@ -723,7 +723,8 @@ class DistributedAttention(nn.Module):
         # if the num head of kv is not enough to be splitted by sp
         # then we could copy the kv head
         if self.sp_size > num_head_kv:
-            kv = expandKVPacked(kv, self.sp_size, 3)
+            assert self.sp_size % num_head_kv == 0, "the num_head_kv should be divided by sp size."
+            kv = expandKVPacked(kv, self.sp_size // num_head_kv, 3)
         kv = _SeqAllToAll.apply(self.spg, kv, 3, 1)
 
         context = self.local_attn(q, kv, **kwargs)

--- a/internlm/core/parallel/comm/utils.py
+++ b/internlm/core/parallel/comm/utils.py
@@ -224,3 +224,70 @@ def reduce_scatter_raw(
 
     handle = dist.reduce_scatter_tensor(output, input_.contiguous(), op=op, group=process_group, async_op=async_op)
     return output, handle
+
+
+class _ExpandKVPackedFunction(torch.autograd.Function):
+    """
+    Copy the KV head repeat times to support sequence parallel.
+
+    Args:
+        kv: input kv.
+        repeat_times: the repeat number of each head.
+        num_head_dim: the dimension of head number.
+    """
+
+    @staticmethod
+    def forward(ctx, kv, repeat_times, num_head_dim):
+        
+        kv_shape = kv.shape
+        num_heads_kv = kv_shape[num_head_dim]
+
+        ctx.num_head_dim = num_head_dim
+        ctx.num_heads_kv = num_heads_kv
+        
+        # here we construct a repeat index to indicate which dim should copy 
+        repeat_index = [1] * kv.ndim
+        repeat_index[num_head_dim] = repeat_times
+        
+        # split the kv into head num splits
+        kv_splits = torch.chunk(kv, chunks=num_heads_kv, dim=num_head_dim)
+        kv_repeats = []
+        # for each split, we copy it to repeat_times copys.
+        for kv_split in kv_splits:
+            kv_split_repeat = kv_split.repeat(repeat_index)
+            kv_repeats.append(kv_split_repeat)
+        
+        # check the copy head whether is the same
+        # res = torch.cat(kv_repeats, dim=num_head_dim)
+        
+        # chunks = torch.chunk(res, chunks=num_heads_kv, dim=num_head_dim)
+        # for chunk in chunks:
+        #     for i in range(1, repeat_times):
+        #         assert torch.equal(chunk[..., i-1, :], chunk[..., i, :])
+                
+        # last we concat these repeats on the num_head_dim dimension.
+        return torch.cat(kv_repeats, dim=num_head_dim)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        
+        '''
+        For backward, we sum the copy head inside a query group.
+        '''
+
+        num_head_dim = ctx.num_head_dim
+        num_heads_kv = ctx.num_heads_kv
+        
+        # we split the grad into query groups splits.
+        grad_output_splits = torch.chunk(grad_output, chunks=num_heads_kv, dim=num_head_dim)
+        grad_output_sums = []
+        # for each split, we sum the head
+        for grad_output_split in grad_output_splits:
+            grad_output_sum = grad_output_split.sum(dim=num_head_dim, keepdim=True)
+            grad_output_sums.append(grad_output_sum)
+        # then we concat the split sums on the num_head_dim dimension.
+        return torch.cat(grad_output_sums, dim=num_head_dim), None, None
+        
+        
+
+expandKVPacked = _ExpandKVPackedFunction.apply

--- a/tests/test_core/test_pipeline.py
+++ b/tests/test_core/test_pipeline.py
@@ -6,7 +6,7 @@ import torch
 from internlm.core.context import ParallelMode
 from internlm.core.context import global_context as gpc
 from internlm.core.context.parallel_context import Config
-from internlm.model.ops.fusion_ops_import_helper import try_import_FusedAdamW
+from internlm.solver.optimizer.compatible_adamw import new_compatible_adamw
 from internlm.utils.common import get_current_device
 from tests.test_core.utils import (
     MlpModel,
@@ -135,14 +135,12 @@ def exam_pipeline_parallel(args):
         torch_xs = torch.tensor(x_list).to(device).to(torch.float32)
         torch_ys = torch.tensor(y_list).to(device).to(torch.float32)
         torch_model = MlpModel(0, 32, "torch").to(device)
-        adam_extra_kwargs, internlm_adamw = try_import_FusedAdamW()
 
-        torch_optimizer = internlm_adamw(
+        torch_optimizer = new_compatible_adamw(
             params=[{"params": torch_model.parameters(), "weight_decay": config.adam.weight_decay}],
             lr=config.adam.lr,
             betas=(config.adam.adam_beta1, config.adam.adam_beta2),
             eps=config.adam.adam_eps,
-            **adam_extra_kwargs,
         )
 
         # check only forward logits


### PR DESCRIPTION
## Motivation
The kv head number in GQA limits the sequence parallel size.
This feature breaks this limitation which supports the sp size > kv head number.
