### PR TITLE
fix: RewardModelLinear bcast process_group

### DIFF
--- a/internlm/model/modules/linear.py
+++ b/internlm/model/modules/linear.py
@@ -526,9 +526,10 @@ class RewardModelLinear(ScaleColumnParallelLinear):
 
         # broadcast parameters for reward model head layer.
         parallel_mode = get_head_parallel_mode()
-        dist.broadcast(self.weight, gpc.get_ranks_in_group(parallel_mode)[0])
+        process_group = gpc.get_group(parallel_mode)
+        dist.broadcast(self.weight, gpc.get_ranks_in_group(parallel_mode)[0], process_group)
         if bias:
-            dist.broadcast(self.bias, gpc.get_ranks_in_group(parallel_mode)[0])
+            dist.broadcast(self.bias, gpc.get_ranks_in_group(parallel_mode)[0], process_group)
 
 
 def new_linear(


### PR DESCRIPTION
## Motivation

RewardModelLinear bcast should specify process_group.

## Modification

internlm/model/modules/linear.py

