### PR TITLE
fix(enable_qkv_fusion): refine wqkv fusion

### DIFF
--- a/configs/7B_llama2.py
+++ b/configs/7B_llama2.py
@@ -152,6 +152,8 @@ model = dict(
     # qk_interleaved = True: q[-1] = [q1,q2,q3,q4,q5,q6,...], k[-1] = [k1,k2,k3,k4,k5,k6,...]
     # qk_interleaved = False: q[-1] = [q1,q3,q5,...,q2,q4,q6,...], k[-1] = [k1,k3,k5,...,k2,k4,k6,...]
     qk_interleaved=False,
+    mlp_layer_fusion=True,
+    enable_qkv_fusion=True,
 )
 
 """

--- a/internlm/model/modeling_llama.py
+++ b/internlm/model/modeling_llama.py
@@ -107,6 +107,7 @@ class Llama2Decoder(nn.Module):
         rope_base: int = 10000,
         mlp_layer_fusion: bool = False,
         multiple_of: int = 256,
+        enable_qkv_fusion: bool = False,
     ):
         super().__init__()
         self.checkpoint = checkpoint
@@ -138,7 +139,7 @@ class Llama2Decoder(nn.Module):
             qk_interleaved=qk_interleaved,
             bias=not no_bias,
             rope_base=rope_base,
-            enable_qkv_fusion=True,
+            enable_qkv_fusion=enable_qkv_fusion,
         )
 
         self.dropout1 = nn.Dropout(drop_rate)
@@ -363,6 +364,7 @@ class Llama2(BaseModel):
         rope_base: int = 10000,
         mlp_layer_fusion: bool = False,
         multiple_of: int = 256,
+        enable_qkv_fusion: bool = False,
     ):
         super().__init__()
 
@@ -410,6 +412,7 @@ class Llama2(BaseModel):
                     rope_base=rope_base,
                     mlp_layer_fusion=mlp_layer_fusion,
                     multiple_of=multiple_of,
+                    enable_qkv_fusion=enable_qkv_fusion,
                 )
                 for lid in range(num_layers)
             ]


### PR DESCRIPTION
## Motivation

Fix some bugs in wqkv fusion

## Modification

1. add hook for `wqkv fusion` to load and save splitted `wq/wk/wv` weights
2. fix some typos
3. `enable_qkv_fusion` can be set through configs

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
