### PR TITLE
fix(enable_qkv_fusion): minor fix for qkv fusion

### DIFF
--- a/internlm/model/modules/mha.py
+++ b/internlm/model/modules/mha.py
@@ -11,7 +11,6 @@ from torch import nn
 from torch.nn import functional as F
 
 from internlm.core.context import global_context as gpc
-from internlm.core.context.process_group_initializer import ParallelMode
 from internlm.model.modules.embedding import new_rotary_embedding
 from internlm.model.modules.linear import new_linear
 from internlm.model.modules.utils import update_kv_cache
@@ -37,12 +36,12 @@ def _convert_cu_seqlens_for_qksplited(kwargs: Dict):
 
 
 def split_fused_wqkv_weight(wqkv, *args, **kwargs):  # pylint: disable=W0613
-    tp_size = gpc.get_world_size(ParallelMode.TENSOR)
-    assert kwargs["q_dim"] % tp_size == 0
-    assert kwargs["kv_dim"] % tp_size == 0
-    q_dim = kwargs["q_dim"] // tp_size
-    kv_dim = kwargs["kv_dim"] // tp_size
-    wq, wk, wv = torch.split(wqkv, [q_dim, kv_dim, kv_dim], dim=0)
+    q_dim = kwargs["q_dim"]
+    kv_dim = kwargs["kv_dim"]
+    split_size = [q_dim, kv_dim, kv_dim]
+    assert (q_dim + 2 * kv_dim) % wqkv.size(0) == 0
+    divisor = (q_dim + 2 * kv_dim) // wqkv.size(0)
+    wq, wk, wv = torch.split(wqkv, [x // divisor for x in split_size], dim=0)
     return wq, wk, wv
 
 

--- a/internlm/model/modules/mha.py
+++ b/internlm/model/modules/mha.py
@@ -11,6 +11,7 @@ from torch import nn
 from torch.nn import functional as F
 
 from internlm.core.context import global_context as gpc
+from internlm.core.context.process_group_initializer import ParallelMode
 from internlm.model.modules.embedding import new_rotary_embedding
 from internlm.model.modules.linear import new_linear
 from internlm.model.modules.utils import update_kv_cache
@@ -36,8 +37,11 @@ def _convert_cu_seqlens_for_qksplited(kwargs: Dict):
 
 
 def split_fused_wqkv_weight(wqkv, *args, **kwargs):  # pylint: disable=W0613
-    q_dim = kwargs["q_dim"]
-    kv_dim = kwargs["kv_dim"]
+    tp_size = gpc.get_world_size(ParallelMode.TENSOR)
+    assert kwargs["q_dim"] % tp_size == 0
+    assert kwargs["kv_dim"] % tp_size == 0
+    q_dim = kwargs["q_dim"] // tp_size
+    kv_dim = kwargs["kv_dim"] // tp_size
     wq, wk, wv = torch.split(wqkv, [q_dim, kv_dim, kv_dim], dim=0)
     return wq, wk, wv
 

--- a/internlm/train/pipeline.py
+++ b/internlm/train/pipeline.py
@@ -934,10 +934,12 @@ def inject_model_helper(model: Union[nn.Module, nn.ModuleList], inject_info: Opt
         for mod in modules:
             inject_funcs[mod](_chunk, inject, interactive)
 
-    # reset parameters
+    # reset parameters and move model to device
     for _chunk in model:
-        if inject and reset_params:
-            _chunk.reset_parameters()
+        if inject:
+            if reset_params:
+                _chunk.reset_parameters()
+            _chunk.to(get_current_device())
 
     # inject configs
     if inject:


### PR DESCRIPTION
## Motivation

1. (Fix for this PR, https://github.com/InternLM/InternEvo/pull/338) q_dim and kv_dim should be divided in the nn.Modules hooks, when tp/wp is enabled.
2. refine dispatch modules: move model.to(device) to `inject_model_helper`, to support larger parameter size

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

None

## Use cases (Optional)

None

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
