### PR TITLE
fix(isp.py): fix isp overlap backward allgather twice when activation ckpt 0.x

### DIFF
--- a/internlm/core/parallel/comm/isp.py
+++ b/internlm/core/parallel/comm/isp.py
@@ -692,6 +692,12 @@ class ISPCommunicatorSchedulerHook(SchedulerHook):
         if self._isp_communicator and self._isp_communicator.overlap:
             self._zero_optim.accumulate_left_grads_after_backward()
 
+            if (
+                getattr(gpc.config.parallel["pipeline"], "mode", "1F1B").upper() in ["ZBV", "ZBH1"]
+                and not self._zero_optim.skip_grad_reduce
+            ):
+                self._zero_optim.reduce_left_grads_after_backward()
+
     def post_helper_func(self, scheduler, outputs, label) -> None:  # pylint: disable=W0613
         pass
 

--- a/internlm/core/parallel/comm/isp.py
+++ b/internlm/core/parallel/comm/isp.py
@@ -488,8 +488,8 @@ class ISPCommunicator(WPCommunicator):
         self._wait_handle(module)
 
     def _post_forward_hook_for_module(self, module: nn.Module, *args):  # pylint: disable=W0613
-        self._clear_handle(module)
         if not ((self._module_to_index[module] < self._ckpt_block_num) and self.is_forward is False):
+            self._clear_handle(module)
             self._clear_weight(module)
 
     def _pre_backward_hook_for_module(self, module: nn.Module, *args):  # pylint: disable=W0613
@@ -691,12 +691,6 @@ class ISPCommunicatorSchedulerHook(SchedulerHook):
         # accumulate left gradients in last bucket after backward.
         if self._isp_communicator and self._isp_communicator.overlap:
             self._zero_optim.accumulate_left_grads_after_backward()
-
-            if (
-                getattr(gpc.config.parallel["pipeline"], "mode", "1F1B").upper() in ["ZBV", "ZBH1"]
-                and not self._zero_optim.skip_grad_reduce
-            ):
-                self._zero_optim.reduce_left_grads_after_backward()
 
     def post_helper_func(self, scheduler, outputs, label) -> None:  # pylint: disable=W0613
         pass

--- a/internlm/model/modeling_internlm.py
+++ b/internlm/model/modeling_internlm.py
@@ -138,7 +138,7 @@ class InternLM1Decoder(nn.Module):
             mlp_layer_fusion=mlp_layer_fusion,
             multiple_of=multiple_of,
             # TODO: to support more activation functions
-            activation_type="swiglu" if use_swiglu else "swiglu",
+            activation_type="swiglu" if use_swiglu else "gelu",
         )
 
         self.use_swiglu = use_swiglu

--- a/internlm/model/modeling_internlm2.py
+++ b/internlm/model/modeling_internlm2.py
@@ -165,7 +165,7 @@ class InternLM2Decoder(nn.Module):
             mlp_layer_fusion=mlp_layer_fusion,
             multiple_of=multiple_of,
             # TODO: to support more activation functions
-            activation_type="swiglu" if use_swiglu else "swiglu",
+            activation_type="swiglu" if use_swiglu else "gelu",
         )
 
         self.use_swiglu = use_swiglu

--- a/internlm/model/modeling_llama.py
+++ b/internlm/model/modeling_llama.py
@@ -157,7 +157,7 @@ class Llama2Decoder(nn.Module):
             mlp_layer_fusion=mlp_layer_fusion,
             multiple_of=multiple_of,
             # TODO: to support more activation functions
-            activation_type="swiglu" if use_swiglu else "swiglu",
+            activation_type="swiglu" if use_swiglu else "gelu",
         )
 
         self.use_swiglu = use_swiglu

--- a/internlm/model/modeling_mixtral.py
+++ b/internlm/model/modeling_mixtral.py
@@ -138,7 +138,7 @@ class MixtralMoEDecoder(nn.Module):
                 mlp_layer_fusion=mlp_layer_fusion,
                 multiple_of=multiple_of,
                 # TODO: to support more activation functions
-                activation_type="swiglu" if use_swiglu else "swiglu",
+                activation_type="swiglu" if use_swiglu else "gelu",
             )
         else:
             # replace mlp by MoE module. The expert in MoE is a FeedForward module.
@@ -156,7 +156,7 @@ class MixtralMoEDecoder(nn.Module):
                 mlp_layer_fusion=mlp_layer_fusion,
                 multiple_of=multiple_of,
                 # TODO: to support more activation functions
-                activation_type="swiglu" if use_swiglu else "swiglu",
+                activation_type="swiglu" if use_swiglu else "gelu",
             )
 
         self.use_swiglu = use_swiglu

--- a/internlm/model/modeling_moe.py
+++ b/internlm/model/modeling_moe.py
@@ -129,7 +129,7 @@ class Internlm1MoEDecoder(nn.Module):
                 mlp_layer_fusion=mlp_layer_fusion,
                 multiple_of=multiple_of,
                 # TODO: to support more activation functions
-                activation_type="swiglu" if use_swiglu else "swiglu",
+                activation_type="swiglu" if use_swiglu else "gelu",
             )
         else:
             # replace mlp by MoE module. The expert in MoE is a FeedForward module.
@@ -147,7 +147,7 @@ class Internlm1MoEDecoder(nn.Module):
                 mlp_layer_fusion=mlp_layer_fusion,
                 multiple_of=multiple_of,
                 # TODO: to support more activation functions
-                activation_type="swiglu" if use_swiglu else "swiglu",
+                activation_type="swiglu" if use_swiglu else "gelu",
             )
 
         self.use_swiglu = use_swiglu


### PR DESCRIPTION
**bug修复1**
由于handle与weight删除不同步，导致在backward时，且activation ckpt值为小数时，会出现ckpt layer的backward阶段进行两次all gather操作的情况，即为重计算all gather一次，backward all gather一次。这里改成handle与weight同步删除，修复此bug。

**bug修复2**
修复mlp初始化时 activation_type(swiglu/gelu)传参错误
