### PR TITLE
support fp32 all_reduce and reduce_scatter

### DIFF
--- a/internlm/core/parallel/comm/utils.py
+++ b/internlm/core/parallel/comm/utils.py
@@ -34,14 +34,15 @@ class WrappedHandle:
     Handle precision conversion when async all_reduce or reduce_scatter
     """
 
-    def __init__(self, handle, output):
+    def __init__(self, handle, output, dtype):
         self.handle = handle
         self.output = output
+        self.dtype = dtype
 
     def wait(self):
         self.handle.wait()
-        if gpc.config.reduce_comm_dtype != gpc.config.model.dtype:
-            self.output.data = self.output.to(gpc.config.model.dtype)
+        if gpc.config.reduce_comm_dtype != self.dtype:
+            self.output.data = self.output.to(self.dtype)
         self.output = None
 
 
@@ -55,7 +56,7 @@ def all_reduce_raw(input_: Tensor, process_group: ProcessGroup, async_op: bool =
         if async_op is False:
             input_ = input_.to(gpc.config.model.dtype)
         else:
-            handle = WrappedHandle(handle=handle, output=input_)
+            handle = WrappedHandle(handle=handle, output=input_, dtype=gpc.config.model.dtype)
     return input_, handle
 
 
@@ -285,7 +286,7 @@ def reduce_scatter_raw(
         if async_op is False:
             output = output.to(gpc.config.model.dtype)
         else:
-            handle = WrappedHandle(handle=handle, output=output)
+            handle = WrappedHandle(handle=handle, output=output, dtype=gpc.config.model.dtype)
     return output, handle
 
 

--- a/internlm/core/scheduler/no_pipeline_scheduler.py
+++ b/internlm/core/scheduler/no_pipeline_scheduler.py
@@ -136,7 +136,11 @@ class NonPipelineScheduler(BaseScheduler):
                 # the moe_loss is computed among the "tensor" group if sequence parallel is enabled,
                 # so we need to do allreduce
                 if gpc.config.parallel.sequence_parallel or gpc.config.parallel.expert.no_tp:
+                    if gpc.config.reduce_comm_dtype != gpc.config.model.dtype:
+                        moe_loss = moe_loss.to(gpc.config.reduce_comm_dtype)
                     dist.all_reduce(moe_loss, op=dist.ReduceOp.SUM, group=gpc.get_group(ParallelMode.TENSOR))
+                    if gpc.config.reduce_comm_dtype != gpc.config.model.dtype:
+                        moe_loss = moe_loss.to(gpc.config.model.dtype)
                     moe_loss.div_(gpc.get_world_size(ParallelMode.TENSOR))
                 moe_loss /= scale_loss
                 loss /= scale_loss

--- a/internlm/core/scheduler/pipeline_scheduler_1f1b.py
+++ b/internlm/core/scheduler/pipeline_scheduler_1f1b.py
@@ -320,7 +320,11 @@ class PipelineScheduler(BaseScheduler):
         )
         # the moe_loss is computed among the "tensor" group if sequence parallel is enabled, so we need to do allreduce
         if gpc.config.parallel.sequence_parallel or gpc.config.parallel.expert.no_tp:
+            if gpc.config.reduce_comm_dtype != gpc.config.model.dtype:
+                moe_loss = moe_loss.to(gpc.config.reduce_comm_dtype)
             dist.all_reduce(moe_loss, op=dist.ReduceOp.SUM, group=gpc.get_group(ParallelMode.TENSOR))
+            if gpc.config.reduce_comm_dtype != gpc.config.model.dtype:
+                moe_loss = moe_loss.to(gpc.config.model.dtype)
             moe_loss.div_(gpc.get_world_size(ParallelMode.TENSOR))
         moe_loss /= self.num_microbatches
         accum_moe_loss.add_(moe_loss.detach())
@@ -458,7 +462,11 @@ class PipelineScheduler(BaseScheduler):
         output, label = pack_return_tensors(return_tensors) if len(return_tensors) > 0 else (None, None)
 
         if hasattr(gpc.config.model, "num_experts") and gpc.config.model.num_experts > 1:
+            if gpc.config.reduce_comm_dtype != gpc.config.model.dtype:
+                accum_moe_loss = accum_moe_loss.to(gpc.config.reduce_comm_dtype)
             dist.all_reduce(accum_moe_loss, group=gpc.get_group(ParallelMode.PIPELINE))
+            if gpc.config.reduce_comm_dtype != gpc.config.model.dtype:
+                accum_moe_loss = accum_moe_loss.to(gpc.config.model.dtype)
 
         if accum_loss is not None:
             accum_loss += accum_moe_loss
@@ -662,7 +670,11 @@ class PipelineScheduler(BaseScheduler):
         output, label = pack_return_tensors(return_tensors) if len(return_tensors) > 0 else (None, None)
 
         if hasattr(gpc.config.model, "num_experts") and gpc.config.model.num_experts > 1:
+            if gpc.config.reduce_comm_dtype != gpc.config.model.dtype:
+                accum_moe_loss = accum_moe_loss.to(gpc.config.reduce_comm_dtype)
             dist.all_reduce(accum_moe_loss, group=gpc.get_group(ParallelMode.PIPELINE))
+            if gpc.config.reduce_comm_dtype != gpc.config.model.dtype:
+                accum_moe_loss = accum_moe_loss.to(gpc.config.model.dtype)
 
         if accum_loss is not None:
             accum_loss += accum_moe_loss
@@ -883,7 +895,12 @@ class InterleavedPipelineScheduler(PipelineScheduler):
         )
         # the moe_loss is computed among the "tensor" group if sequence parallel is enabled, so we need to do allreduce
         if gpc.config.parallel.sequence_parallel or gpc.config.parallel.expert.no_tp:
+            if gpc.config.reduce_comm_dtype != gpc.config.model.dtype:
+                moe_loss = moe_loss.to(gpc.config.reduce_comm_dtype)
             dist.all_reduce(moe_loss, op=dist.ReduceOp.AVG, group=gpc.get_group(ParallelMode.TENSOR))
+            if gpc.config.reduce_comm_dtype != gpc.config.model.dtype:
+                moe_loss = moe_loss.to(gpc.config.model.dtype)
+
         moe_loss /= self.num_microbatches
 
         if self._accum_moe_loss is not None:
@@ -1414,7 +1431,11 @@ class InterleavedPipelineScheduler(PipelineScheduler):
             output, label = (None, None)
 
         if hasattr(gpc.config.model, "num_experts") and gpc.config.model.num_experts > 1:
+            if gpc.config.reduce_comm_dtype != gpc.config.model.dtype:
+                self._accum_moe_loss = self._accum_moe_loss.to(gpc.config.reduce_comm_dtype)
             dist.all_reduce(self._accum_moe_loss, group=gpc.get_group(ParallelMode.PIPELINE))
+            if gpc.config.reduce_comm_dtype != gpc.config.model.dtype:
+                self._accum_moe_loss = self._accum_moe_loss.to(gpc.config.model.dtype)
         accum_moe_loss = self._accum_moe_loss
 
         accum_loss = self._accum_loss

--- a/internlm/initialize/launch.py
+++ b/internlm/initialize/launch.py
@@ -484,6 +484,22 @@ def args_sanity_check():
     if "early_reduce_scatter_release" not in gpc.config.parallel.expert_weight:
         gpc.config.parallel.expert_weight["early_reduce_scatter_release"] = True
 
+    # the comm_dtype for reduce communication
+    if gpc.config.get("reduce_comm_dtype", None) is None:
+        gpc.config.reduce_comm_dtype = gpc.config.model.dtype
+    else:
+        if gpc.config.reduce_comm_dtype == "torch.bfloat16":
+            gpc.config.reduce_comm_dtype = torch.bfloat16
+        elif gpc.config.reduce_comm_dtype == "torch.float32":
+            gpc.config.reduce_comm_dtype = torch.float32
+        else:
+            assert gpc.config.reduce_comm_dtype in [
+                "torch.bfloat16",
+                "torch.float32",
+            ]
+        if gpc.config.model.dtype == torch.float32:
+            assert gpc.config.reduce_comm_dtype == gpc.config.model.dtype
+
     # currently only interleaved pipeline scheduler with overlap can guarantee loss accuracy
     if hasattr(gpc.config.model, "num_chunks") and gpc.config.model.num_chunks > 1:
         assert (

--- a/internlm/solver/optimizer/utils.py
+++ b/internlm/solver/optimizer/utils.py
@@ -12,6 +12,7 @@ from torch._utils import _flatten_dense_tensors, _unflatten_dense_tensors
 
 from internlm.core.context import ParallelMode
 from internlm.core.context import global_context as gpc
+from internlm.core.parallel.comm.utils import WrappedHandle
 from internlm.utils.common import get_current_device, get_tensor_norm, move_norm_to_cuda
 from internlm.utils.logger import get_logger
 from internlm.utils.parallel import (
@@ -79,23 +80,6 @@ def split_half_float_double(tensor_list):
 
     buckets = [bucket for bucket in dtype_buckets.values() if bucket]
     return buckets
-
-
-class WrappedHandle:
-    """
-    Handle precision conversion when async all_reduce or reduce_scatter
-    """
-
-    def __init__(self, handle, output, dtype):
-        self.handle = handle
-        self.output = output
-        self.dtype = dtype
-
-    def wait(self):
-        self.handle.wait()
-        if gpc.config.reduce_comm_dtype != self.dtype:
-            self.output.data = self.output.to(self.dtype)
-        self.output = None
 
 
 def reduce_tensor(


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

support fp32 all_reduce and reduce_scatter

## Modification

add reduce_comm_dtype to decide whether use float32 or bfloat16 to compute tensor in all_reduce and reduce_scatter communication.

internlm using isp parallel with sp size 2, weight size 2. The loss is as follows:
![image](https://github.com/user-attachments/assets/55b8f897-54ea-4495-9c65-d04bb4c2d843)
Using bf16 reduce, compared with original code without this feature, the loss diversity is within 1e-2.
While using fp32 reduce, loss is different from bf16 reduce.

the tgs is as follows:
![image](https://github.com/user-attachments/assets/07f66609-339f-483a-87e4-c1eab20611f1)

The following is 7B moe module, with pipeline parallel size 2.
loss:
![image](https://github.com/user-attachments/assets/c9a9d0ce-982a-4784-b00a-865fa28556f3)

tgs:
![image](https://github.com/user-attachments/assets/e5421113-1009-4d76-91f7-a08e720a502d)


## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
