### PR TITLE
fix(CI): fix lint check in CI

### DIFF
--- a/.github/workflows/lint_check.yaml
+++ b/.github/workflows/lint_check.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   # lint check can be auto-executed by the workflow
   lint-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
 


### PR DESCRIPTION

## Motivation

When run lint check in CI, there is an error
![img_v3_02i3_0a257e5c-5a87-4239-9fe3-deafbfb4cbag](https://github.com/user-attachments/assets/2a88277f-9201-475c-81a0-e4640f8fac13)
This pr fix this

## Modification

.github/workflows/lint_check.yaml

